### PR TITLE
6 limit group membership to owners

### DIFF
--- a/app/components/gaming_group_user_overview_component.rb
+++ b/app/components/gaming_group_user_overview_component.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 
 class GamingGroupUserOverviewComponent < ViewComponent::Base
-  def initialize(gaming_group:)
+  def initialize(gaming_group:, current_user:)
     @gaming_group = gaming_group
+    @current_user = current_user
   end
 
   def name(user)
@@ -11,16 +12,18 @@ class GamingGroupUserOverviewComponent < ViewComponent::Base
   end
 
   def draw_menu(user, membership_text)
-    content_tag(:div, class: "dropdown record-show-wrapper_header-menu") do
-      concat(content_tag(:button, class: "btn btn-secondary dropdown-toggle", type: :button, data: {
-        "bs-toggle": "dropdown"
-      }) do
-        content_tag(:i, nil, class: "bi bi-gear-fill")
-      end)
-      concat(content_tag(:ul, class: "dropdown-menu") do
-        concat(content_tag(:li, button_to(membership_text, update_membership_gaming_group_path(@gaming_group, {user_id: user.id}), method: :post, class: "dropdown-item")))
-        concat(content_tag(:li, button_to("Remove from group", remove_user_gaming_group_path(@gaming_group, {user_id: user.id}), method: :post, class: "dropdown-item")))
-      end)
+    if @gaming_group.is_owner?(@current_user)
+      content_tag(:div, class: "dropdown record-show-wrapper_header-menu") do
+        concat(content_tag(:button, class: "btn btn-secondary dropdown-toggle", type: :button, data: {
+          "bs-toggle": "dropdown"
+        }) do
+          content_tag(:i, nil, class: "bi bi-gear-fill")
+        end)
+        concat(content_tag(:ul, class: "dropdown-menu") do
+          concat(content_tag(:li, button_to(membership_text, update_membership_gaming_group_path(@gaming_group, {user_id: user.id}), method: :post, class: "dropdown-item")))
+          concat(content_tag(:li, button_to("Remove from group", remove_user_gaming_group_path(@gaming_group, {user_id: user.id}), method: :post, class: "dropdown-item")))
+        end)
+      end
     end
   end
 end

--- a/app/components/gaming_group_user_overview_component/gaming_group_user_overview_component.html.erb
+++ b/app/components/gaming_group_user_overview_component/gaming_group_user_overview_component.html.erb
@@ -42,8 +42,10 @@
     </ul>
   </div>
 
-  <div class=mt-2>
-    <%= render UserInviteModalComponent.new(gaming_group: @gaming_group) %>
-  </div>
+  <% if @gaming_group.is_owner?(@current_user) %>
+    <div class=mt-2>
+      <%= render UserInviteModalComponent.new(gaming_group: @gaming_group) %>
+    </div>
+  <% end %>
 
 </div>

--- a/app/components/user_invite_modal_component/user_invite_modal_component.html.erb
+++ b/app/components/user_invite_modal_component/user_invite_modal_component.html.erb
@@ -1,5 +1,5 @@
 <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#userInviteModal">
-  Inivte User 
+  Invite User 
 </button>
 
 <div class="modal" tabindex="-1" id="userInviteModal">

--- a/app/controllers/gaming_groups_controller.rb
+++ b/app/controllers/gaming_groups_controller.rb
@@ -1,5 +1,7 @@
 class GamingGroupsController < ApplicationController
   before_action :set_gaming_group, only: %i[show edit update destroy update_membership remove_user invite_user]
+  before_action :check_owner, only: %i[update edit update_membership remove_user invite_user destroy]
+  before_action :check_member, only: %i[show]
 
   # GET /gaming_groups or /gaming_groups.json
   def index
@@ -89,6 +91,14 @@ class GamingGroupsController < ApplicationController
   end
 
   private
+
+  def check_member
+    redirect_to(root_url, alert: "You cannot access this group") unless @gaming_group.is_user?(current_user)
+  end
+
+  def check_owner
+    redirect_to(@gaming_group, alert: "You cannot perform this action as you are not the owner") unless @gaming_group.is_owner?(current_user)
+  end
 
   # Use callbacks to share common setup or constraints between actions.
   def set_gaming_group

--- a/app/controllers/gaming_sessions_controller.rb
+++ b/app/controllers/gaming_sessions_controller.rb
@@ -1,10 +1,6 @@
 class GamingSessionsController < ApplicationController
   before_action :set_gaming_session, only: %i[show edit update destroy]
-
-  # GET /gaming_sessions or /gaming_sessions.json
-  def index
-    @gaming_sessions = GamingSession.all
-  end
+  before_action :has_access, only: %i[show edit update destroy]
 
   # GET /gaming_sessions/1 or /gaming_sessions/1.json
   def show
@@ -58,6 +54,10 @@ class GamingSessionsController < ApplicationController
   end
 
   private
+
+  def has_access
+    @gaming_session.gaming_group.is_user?(current_user)
+  end
 
   # Use callbacks to share common setup or constraints between actions.
   def set_gaming_session

--- a/app/models/gaming_group.rb
+++ b/app/models/gaming_group.rb
@@ -5,6 +5,10 @@ class GamingGroup < ApplicationRecord
 
   validates :name, presence: true
 
+  def is_user?(user)
+    users.find_by(id: user.id).present?
+  end
+
   def owners
     users.joins(:user_group_memberships).where(user_group_memberships: {owner: true})
   end

--- a/app/views/gaming_groups/show.html.erb
+++ b/app/views/gaming_groups/show.html.erb
@@ -7,7 +7,7 @@
       <%= render GroupSessionsOverviewComponent.new(gaming_group: @gaming_group) %>
     </div>
     <div class="col">
-      <%= render GamingGroupUserOverviewComponent.new(gaming_group: @gaming_group) %>
+      <%= render GamingGroupUserOverviewComponent.new(gaming_group: @gaming_group, current_user:) %>
     </div>
   </div>
 </div>

--- a/app/views/gaming_sessions/_gaming_session.html.erb
+++ b/app/views/gaming_sessions/_gaming_session.html.erb
@@ -1,9 +1,4 @@
 <p>
-  <strong>Start time:</strong>
-  <%= gaming_session.start_time %>
-</p>
-
-<p>
   <strong>Gaming group:</strong>
   <%= gaming_session.gaming_group.name %>
 </p>

--- a/app/views/gaming_sessions/show.html.erb
+++ b/app/views/gaming_sessions/show.html.erb
@@ -3,7 +3,7 @@
     <div class="col">
       <%= render RecordShowWrapperComponent.new(
         record: @gaming_session,
-        title: @gaming_session.to_s,
+        title: l(@gaming_session.start_time),
         menu_options: [
           { 
             text: "Edit",

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   resources :gaming_systems
   resources :games
-  resources :gaming_sessions
+  resources :gaming_sessions, except: %i[index]
   resources :gaming_groups do
     member do
       post :update_membership

--- a/spec/components/gaming_group_user_overview_component_spec.rb
+++ b/spec/components/gaming_group_user_overview_component_spec.rb
@@ -14,18 +14,52 @@ RSpec.describe GamingGroupUserOverviewComponent, type: :component do
     create(:user_group_membership, user:, gaming_group:, owner: false)
     user
   }
-
   before do
     member
     owner
-    render_inline(described_class.new(gaming_group:))
   end
 
-  it "should render a card" do
-    expect(page).to have_css(".card")
+  context "with owner" do
+    before do
+      render_inline(described_class.new(gaming_group:, current_user: owner))
+    end
+
+    it "should render a card" do
+      expect(page).to have_css(".card")
+    end
+
+    it "should render two list groups" do
+      expect(page).to have_css(".list-group", count: 2)
+    end
+
+    it "should render menu" do
+      expect(page).to have_css(".record-show-wrapper_header-menu")
+    end
+
+    it "should render invite menu" do
+      expect(page).to have_css(".btn", text: /Invite User/)
+    end
   end
 
-  it "should render two list groups" do
-    expect(page).to have_css(".list-group", count: 2)
+  context "with member" do
+    before do
+      render_inline(described_class.new(gaming_group:, current_user: member))
+    end
+
+    it "should render a card" do
+      expect(page).to have_css(".card")
+    end
+
+    it "should render two list groups" do
+      expect(page).to have_css(".list-group", count: 2)
+    end
+
+    it "should not render menu" do
+      expect(page).not_to have_css(".record-show-wrapper_header-menu")
+    end
+
+    it "should not render invite menu" do
+      expect(page).not_to have_css(".btn", text: /Invite User/)
+    end
   end
 end

--- a/spec/models/gaming_group_spec.rb
+++ b/spec/models/gaming_group_spec.rb
@@ -15,6 +15,8 @@ RSpec.describe GamingGroup, type: :model do
     user
   }
 
+  let(:not_member) { create(:user) }
+
   context "attributes" do
     it { expect(gaming_group).to have_attributes(name: "Test") }
   end
@@ -30,5 +32,11 @@ RSpec.describe GamingGroup, type: :model do
   it "should correctly return for is_owner?" do
     expect(gaming_group.is_owner?(owner)).to be true
     expect(gaming_group.is_owner?(member)).to be false
+  end
+
+  it "should correctly return for is_user?" do
+    expect(gaming_group.is_user?(owner)).to be true
+    expect(gaming_group.is_user?(member)).to be true
+    expect(gaming_group.is_user?(not_member)).to be false
   end
 end

--- a/spec/requests/gaming_groups_spec.rb
+++ b/spec/requests/gaming_groups_spec.rb
@@ -13,9 +13,19 @@ require "rails_helper"
 # sticking to rails and rspec-rails APIs to keep things simple and stable.
 
 RSpec.describe "/gaming_groups", type: :request do
-  # This should return the minimal set of attributes required to create a valid
-  # GamingGroup. As you add validations to GamingGroup, be sure to
-  # adjust the attributes here as well.
+  let(:gaming_group) { create(:gaming_group) }
+  let(:owner) {
+    user = create(:user)
+    create(:user_group_membership, user:, gaming_group:, owner: true)
+    user
+  }
+  let(:member) {
+    user = create(:user)
+    create(:user_group_membership, user:, gaming_group:, owner: false)
+    user
+  }
+  let(:non_member) { create(:user) }
+
   let(:valid_attributes) {
     {
       name: "test group"
@@ -28,179 +38,277 @@ RSpec.describe "/gaming_groups", type: :request do
     }
   }
 
-  before do
-    sign_in create(:user)
-  end
+  let(:new_attributes) {
+    {
+      name: "Other name"
+    }
+  }
 
-  describe "GET /index" do
-    it "renders a successful response" do
-      GamingGroup.create! valid_attributes
-      get gaming_groups_url
-      expect(response).to be_successful
+  describe "non member user" do
+    before do
+      sign_in(non_member)
+    end
+
+    describe "GET /show" do
+      it "should redirect to home for non member user" do
+        get gaming_group_url(gaming_group)
+        expect(response).to redirect_to(root_url)
+      end
     end
   end
 
-  describe "GET /show" do
-    it "renders a successful response" do
-      gaming_group = GamingGroup.create! valid_attributes
-      get gaming_group_url(gaming_group)
-      expect(response).to be_successful
+  describe "as standard user" do
+    before do
+      sign_in(member)
     end
-  end
 
-  describe "GET /new" do
-    it "renders a successful response" do
-      get new_gaming_group_url
-      expect(response).to be_successful
+    describe "GET /index" do
+      it "renders a successful response" do
+        get gaming_groups_url
+        expect(response).to be_successful
+      end
     end
-  end
 
-  describe "GET /edit" do
-    it "renders a successful response" do
-      gaming_group = GamingGroup.create! valid_attributes
-      get edit_gaming_group_url(gaming_group)
-      expect(response).to be_successful
+    describe "GET /show" do
+      it "renders a successful response" do
+        get gaming_group_url(gaming_group)
+        expect(response).to be_successful
+      end
     end
-  end
 
-  describe "POST /create" do
-    context "with valid parameters" do
-      it "creates a new GamingGroup" do
-        expect {
+    describe "GET /new" do
+      it "renders a successful response" do
+        get new_gaming_group_url
+        expect(response).to be_successful
+      end
+    end
+
+    describe "GET /edit" do
+      it "should redirect to show" do
+        get edit_gaming_group_url(gaming_group)
+        expect(response).to redirect_to(gaming_group)
+      end
+    end
+    describe "POST /create" do
+      context "with valid parameters" do
+        it "creates a new GamingGroup" do
+          expect {
+            post gaming_groups_url, params: {gaming_group: valid_attributes}
+          }.to change(GamingGroup, :count).by(1)
+        end
+
+        it "redirects to the created gaming_group" do
           post gaming_groups_url, params: {gaming_group: valid_attributes}
-        }.to change(GamingGroup, :count).by(1)
+          expect(response).to redirect_to(gaming_group_url(GamingGroup.order(:created_at).last))
+        end
       end
 
-      it "redirects to the created gaming_group" do
-        post gaming_groups_url, params: {gaming_group: valid_attributes}
-        expect(response).to redirect_to(gaming_group_url(GamingGroup.last))
-      end
-    end
+      context "with invalid parameters" do
+        it "does not create a new GamingGroup" do
+          expect {
+            post gaming_groups_url, params: {gaming_group: invalid_attributes}
+          }.to change(GamingGroup, :count).by(0)
+        end
 
-    context "with invalid parameters" do
-      it "does not create a new GamingGroup" do
-        expect {
+        it "renders a response with 422 status (i.e. to display the 'new' template)" do
           post gaming_groups_url, params: {gaming_group: invalid_attributes}
-        }.to change(GamingGroup, :count).by(0)
-      end
-
-      it "renders a response with 422 status (i.e. to display the 'new' template)" do
-        post gaming_groups_url, params: {gaming_group: invalid_attributes}
-        expect(response).to have_http_status(:unprocessable_entity)
+          expect(response).to have_http_status(:unprocessable_entity)
+        end
       end
     end
-  end
 
-  describe "PATCH /update" do
-    context "with valid parameters" do
-      let(:new_attributes) {
-        {
-          name: "Other name"
-        }
-      }
-
-      it "updates the requested gaming_group" do
-        gaming_group = GamingGroup.create! valid_attributes
-        patch gaming_group_url(gaming_group), params: {gaming_group: new_attributes}
-        gaming_group.reload
-        expect(gaming_group.name).to eq("Other name")
-      end
-
-      it "redirects to the gaming_group" do
-        gaming_group = GamingGroup.create! valid_attributes
+    describe "PATCH /update" do
+      it "should redirect to show" do
         patch gaming_group_url(gaming_group), params: {gaming_group: new_attributes}
         gaming_group.reload
         expect(response).to redirect_to(gaming_group_url(gaming_group))
       end
     end
 
-    context "with invalid parameters" do
-      it "renders a response with 422 status (i.e. to display the 'edit' template)" do
-        gaming_group = GamingGroup.create! valid_attributes
-        patch gaming_group_url(gaming_group), params: {gaming_group: invalid_attributes}
-        expect(response).to have_http_status(:unprocessable_entity)
+    describe "DELETE /destroy" do
+      it "should not destroy record" do
+        expect {
+          delete gaming_group_url(gaming_group)
+        }.to change(GamingGroup, :count).by(0)
+      end
+    end
+
+    context "user management" do
+      describe "POST /update_membership" do
+        it "should redirect to show" do
+          post update_membership_gaming_group_url(gaming_group), params: {user_id: owner.id}
+          expect(response).to redirect_to(gaming_group_url(gaming_group))
+        end
+      end
+
+      describe "POST /remove_user" do
+        it "should redirect to show" do
+          post remove_user_gaming_group_url(gaming_group), params: {user_id: owner.id}
+          expect(response).to redirect_to(gaming_group_url(gaming_group))
+        end
+      end
+
+      describe "POST /invite_user" do
+        let(:email) { Faker::Internet.email }
+        let(:existing_user) { create(:user) }
+
+        it "should redirect to show" do
+          post invite_user_gaming_group_url(gaming_group), params: {email:, owner: false}
+          expect(response).to redirect_to(gaming_group_url(gaming_group))
+        end
       end
     end
   end
 
-  describe "DELETE /destroy" do
-    it "destroys the requested gaming_group" do
-      gaming_group = GamingGroup.create! valid_attributes
-      expect {
+  context "as owner user" do
+    before do
+      sign_in(owner)
+    end
+
+    describe "GET /index" do
+      it "renders a successful response" do
+        get gaming_groups_url
+        expect(response).to be_successful
+      end
+    end
+
+    describe "GET /show" do
+      it "renders a successful response" do
+        get gaming_group_url(gaming_group)
+        expect(response).to be_successful
+      end
+    end
+
+    describe "GET /new" do
+      it "renders a successful response" do
+        get new_gaming_group_url
+        expect(response).to be_successful
+      end
+    end
+
+    describe "GET /edit" do
+      it "renders a successful response" do
+        get edit_gaming_group_url(gaming_group)
+        expect(response).to be_successful
+      end
+    end
+
+    describe "POST /create" do
+      context "with valid parameters" do
+        it "creates a new GamingGroup" do
+          expect {
+            post gaming_groups_url, params: {gaming_group: valid_attributes}
+          }.to change(GamingGroup, :count).by(1)
+        end
+
+        it "redirects to the created gaming_group" do
+          post gaming_groups_url, params: {gaming_group: valid_attributes}
+          expect(response).to redirect_to(gaming_group_url(GamingGroup.order(:created_at).last))
+        end
+      end
+
+      context "with invalid parameters" do
+        it "does not create a new GamingGroup" do
+          expect {
+            post gaming_groups_url, params: {gaming_group: invalid_attributes}
+          }.to change(GamingGroup, :count).by(0)
+        end
+
+        it "renders a response with 422 status (i.e. to display the 'new' template)" do
+          post gaming_groups_url, params: {gaming_group: invalid_attributes}
+          expect(response).to have_http_status(:unprocessable_entity)
+        end
+      end
+    end
+
+    describe "PATCH /update" do
+      context "with valid parameters" do
+        it "updates the requested gaming_group" do
+          patch gaming_group_url(gaming_group), params: {gaming_group: new_attributes}
+          gaming_group.reload
+          expect(gaming_group.name).to eq("Other name")
+        end
+
+        it "redirects to the gaming_group" do
+          patch gaming_group_url(gaming_group), params: {gaming_group: new_attributes}
+          gaming_group.reload
+          expect(response).to redirect_to(gaming_group_url(gaming_group))
+        end
+      end
+
+      context "with invalid parameters" do
+        it "renders a response with 422 status (i.e. to display the 'edit' template)" do
+          patch gaming_group_url(gaming_group), params: {gaming_group: invalid_attributes}
+          expect(response).to have_http_status(:unprocessable_entity)
+        end
+      end
+    end
+
+    describe "DELETE /destroy" do
+      it "destroys the requested gaming_group" do
+        expect {
+          delete gaming_group_url(gaming_group)
+        }.to change(GamingGroup, :count).by(-1)
+      end
+
+      it "redirects to the gaming_groups list" do
         delete gaming_group_url(gaming_group)
-      }.to change(GamingGroup, :count).by(-1)
-    end
-
-    it "redirects to the gaming_groups list" do
-      gaming_group = GamingGroup.create! valid_attributes
-      delete gaming_group_url(gaming_group)
-      expect(response).to redirect_to(gaming_groups_url)
-    end
-  end
-
-  context "users management" do
-    let(:gaming_group) { create(:gaming_group) }
-    let(:owner) {
-      user = create(:user)
-      create(:user_group_membership, user:, gaming_group:, owner: true)
-      user
-    }
-    let(:member) {
-      user = create(:user)
-      create(:user_group_membership, user:, gaming_group:, owner: false)
-      user
-    }
-
-    describe "POST /update_membership" do
-      it "should demote an owner" do
-        post update_membership_gaming_group_url(gaming_group), params: {user_id: owner.id}
-        gaming_group.reload
-        expect(gaming_group.is_owner?(owner)).to be false
-      end
-
-      it "should promote a member" do
-        post update_membership_gaming_group_url(gaming_group), params: {user_id: member.id}
-        gaming_group.reload
-        expect(gaming_group.is_owner?(member)).to be true
+        expect(response).to redirect_to(gaming_groups_url)
       end
     end
 
-    describe "POST /remove_user" do
-      it "should remove an owner" do
-        post remove_user_gaming_group_url(gaming_group), params: {user_id: owner.id}
-        gaming_group.reload
-        expect(gaming_group.users).not_to include(owner)
+    context "users management" do
+      describe "POST /update_membership" do
+        it "should demote an owner" do
+          post update_membership_gaming_group_url(gaming_group), params: {user_id: owner.id}
+          gaming_group.reload
+          expect(gaming_group.is_owner?(owner)).to be false
+        end
+
+        it "should promote a member" do
+          post update_membership_gaming_group_url(gaming_group), params: {user_id: member.id}
+          gaming_group.reload
+          expect(gaming_group.is_owner?(member)).to be true
+        end
       end
 
-      it "should promote a member" do
-        post remove_user_gaming_group_url(gaming_group), params: {user_id: member.id}
-        gaming_group.reload
-        expect(gaming_group.users).not_to include(member)
-      end
-    end
+      describe "POST /remove_user" do
+        it "should remove an owner" do
+          post remove_user_gaming_group_url(gaming_group), params: {user_id: owner.id}
+          gaming_group.reload
+          expect(gaming_group.users).not_to include(owner)
+        end
 
-    describe "POST /invite_user" do
-      let(:email) { Faker::Internet.email }
-      let(:existing_user) { create(:user) }
-
-      it "should invite new user and add as member" do
-        post invite_user_gaming_group_url(gaming_group), params: {email:, owner: false}
-        expect(gaming_group.members).to include(User.find_by(email:))
+        it "should promote a member" do
+          post remove_user_gaming_group_url(gaming_group), params: {user_id: member.id}
+          gaming_group.reload
+          expect(gaming_group.users).not_to include(member)
+        end
       end
 
-      it "should invite new user and add as owner" do
-        post invite_user_gaming_group_url(gaming_group), params: {email:, owner: true}
-        expect(gaming_group.owners).to include(User.find_by(email:))
-      end
+      describe "POST /invite_user" do
+        let(:email) { Faker::Internet.email }
+        let(:existing_user) { create(:user) }
 
-      it "should invite exising user and add as member" do
-        post invite_user_gaming_group_url(gaming_group), params: {email: existing_user.email, owner: false}
-        expect(gaming_group.members).to include(existing_user)
-      end
+        it "should invite new user and add as member" do
+          post invite_user_gaming_group_url(gaming_group), params: {email:, owner: false}
+          expect(gaming_group.members).to include(User.find_by(email:))
+        end
 
-      it "should invite exising user and add as owner" do
-        post invite_user_gaming_group_url(gaming_group), params: {email: existing_user.email, owner: true}
-        expect(gaming_group.owners).to include(existing_user)
+        it "should invite new user and add as owner" do
+          post invite_user_gaming_group_url(gaming_group), params: {email:, owner: true}
+          expect(gaming_group.owners).to include(User.find_by(email:))
+        end
+
+        it "should invite exising user and add as member" do
+          post invite_user_gaming_group_url(gaming_group), params: {email: existing_user.email, owner: false}
+          expect(gaming_group.members).to include(existing_user)
+        end
+
+        it "should invite exising user and add as owner" do
+          post invite_user_gaming_group_url(gaming_group), params: {email: existing_user.email, owner: true}
+          expect(gaming_group.owners).to include(existing_user)
+        end
       end
     end
   end

--- a/spec/requests/gaming_sessions_spec.rb
+++ b/spec/requests/gaming_sessions_spec.rb
@@ -35,14 +35,6 @@ RSpec.describe "/gaming_sessions", type: :request do
     sign_in create(:user)
   end
 
-  describe "GET /index" do
-    it "renders a successful response" do
-      GamingSession.create! valid_attributes
-      get gaming_sessions_url
-      expect(response).to be_successful
-    end
-  end
-
   describe "GET /show" do
     it "renders a successful response" do
       gaming_session = GamingSession.create! valid_attributes

--- a/spec/routing/gaming_sessions_routing_spec.rb
+++ b/spec/routing/gaming_sessions_routing_spec.rb
@@ -2,10 +2,6 @@ require "rails_helper"
 
 RSpec.describe GamingSessionsController, type: :routing do
   describe "routing" do
-    it "routes to #index" do
-      expect(get: "/gaming_sessions").to route_to("gaming_sessions#index")
-    end
-
     it "routes to #new" do
       expect(get: "/gaming_sessions/new").to route_to("gaming_sessions#new")
     end

--- a/spec/views/gaming_groups/show.html.erb_spec.rb
+++ b/spec/views/gaming_groups/show.html.erb_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe "gaming_groups/show", type: :view do
     assign(:gaming_group, GamingGroup.create!(
       name: "Name"
     ))
+    allow(controller).to receive(:current_user) { create(:user) }
   end
 
   it "renders attributes in <p>" do

--- a/spec/views/gaming_sessions/index.html.erb_spec.rb
+++ b/spec/views/gaming_sessions/index.html.erb_spec.rb
@@ -8,6 +8,6 @@ RSpec.describe "gaming_sessions/index", type: :view do
   it "renders a list of gaming_sessions" do
     render
     cell_selector = "div>p"
-    assert_select cell_selector, text: Regexp.new(nil.to_s), count: 6
+    assert_select cell_selector, text: Regexp.new(nil.to_s), count: 4
   end
 end


### PR DESCRIPTION
Closes https://github.com/squancey88/amicis_in_conflictu-project-tracking/issues/6

- Updating gaming group controller to limit edit, update and user actions to owners
- Ensuring user must be in the group to see the associated sessions
- Updates to test suites