### PR TITLE
Sorting out the session overview to only dipslay upcoming

### DIFF
--- a/app/components/group_sessions_overview_component/group_sessions_overview_component.html.erb
+++ b/app/components/group_sessions_overview_component/group_sessions_overview_component.html.erb
@@ -2,15 +2,36 @@
 
   <ul class="nav nav-tabs" id="myTab" role="tablist">
     <li class="nav-item" role="presentation">
-      <button class="nav-link active" id="upcoming-tab" data-bs-toggle="tab" data-bs-target="#upcoming-tab-pane" type="button" role="tab" aria-controls="upcoming-tab-pane" aria-selected="true">Upcoming</button>
+      <button class="nav-link active" id="upcoming-tab" data-bs-toggle="tab" data-bs-target="#upcoming-tab-pane" 
+        type="button" role="tab" aria-controls="upcoming-tab-pane" aria-selected="true">
+        Upcoming
+      </button>
     </li>
     <li class="nav-item" role="presentation">
-      <button class="nav-link" id="calendar-tab" data-bs-toggle="tab" data-bs-target="#calendar-tab-pane" type="button" role="tab" aria-controls="calendar-tab-pane" aria-selected="false">Calendar</button>
+      <button class="nav-link" id="previous-tab" data-bs-toggle="tab" data-bs-target="#previous-tab-pane" 
+        type="button" role="tab" aria-controls="previous-tab-pane" aria-selected="false">
+        Previous
+      </button>
+    </li>
+    <li class="nav-item" role="presentation">
+      <button class="nav-link" id="calendar-tab" data-bs-toggle="tab" data-bs-target="#calendar-tab-pane" 
+        type="button" role="tab" aria-controls="calendar-tab-pane" aria-selected="false">
+        Calendar
+      </button>
     </li>
   </ul>
   <div class="tab-content p-2 border border-top-0" id="myTabContent">
     <div class="tab-pane fade show active" id="upcoming-tab-pane" role="tabpanel" aria-labelledby="upcoming-tab" tabindex="0">
-      <% @gaming_group.gaming_sessions.each do |session| %>
+      <% @gaming_group.gaming_sessions.upcoming.order(:start_time).each do |session| %>
+        <div class="card mb-1">
+          <div class="card-body">
+            <%= link_to(l(session.start_time), session) %>
+          </div>
+        </div>
+      <% end %>
+    </div>
+    <div class="tab-pane fade" id="previous-tab-pane" role="tabpanel" aria-labelledby="previous-tab" tabindex="0">
+      <% @gaming_group.gaming_sessions.previous.limit(10).order(:start_time).each do |session| %>
         <div class="card">
           <div class="card-body">
             <%= link_to(l(session.start_time), session) %>
@@ -19,6 +40,7 @@
       <% end %>
     </div>
     <div class="tab-pane fade" id="calendar-tab-pane" role="tabpanel" aria-labelledby="calendar-tab" tabindex="0">
+      Coming soon...
     </div>
   </div>
 

--- a/app/models/gaming_session.rb
+++ b/app/models/gaming_session.rb
@@ -4,6 +4,9 @@ class GamingSession < ApplicationRecord
 
   validates :start_time, presence: true
 
+  scope :upcoming, ->(limit = 5) { where("start_time > ?", Time.zone.today.beginning_of_day).limit(limit) }
+  scope :previous, -> { where("start_time <= ?", Time.zone.today.beginning_of_day) }
+
   def to_s
     I18n.l(start_time)
   end

--- a/spec/models/gaming_session_spec.rb
+++ b/spec/models/gaming_session_spec.rb
@@ -2,9 +2,35 @@ require "rails_helper"
 
 RSpec.describe GamingSession, type: :model do
   let(:gaming_session) { create(:gaming_session, start_time: "2024/1/1 12:00") }
+  let(:old_gaming_session) { create(:gaming_session, start_time: Time.zone.now.days_ago(2)) }
+  let(:today_gaming_session) { create(:gaming_session, start_time: Time.zone.now) }
+  let(:upcoming_gaming_session) { create(:gaming_session, start_time: 3.hours.from_now) }
 
   context "attributes" do
     it { expect(gaming_session).to have_attributes(start_time: DateTime.parse("2024/1/1 12:00")) }
     it { expect(gaming_session.to_s).to eq(I18n.l(gaming_session.start_time)) }
+  end
+
+  context "scopes" do
+    before do
+      old_gaming_session
+      today_gaming_session
+      upcoming_gaming_session
+    end
+    describe "upcoming" do
+      it "should include correct sessions" do
+        expect(GamingSession.upcoming).not_to include(old_gaming_session)
+        expect(GamingSession.upcoming).to include(today_gaming_session)
+        expect(GamingSession.upcoming).to include(upcoming_gaming_session)
+      end
+    end
+
+    describe "previous" do
+      it "should include correct sessions" do
+        expect(GamingSession.previous).to include(old_gaming_session)
+        expect(GamingSession.previous).not_to include(today_gaming_session)
+        expect(GamingSession.previous).not_to include(upcoming_gaming_session)
+      end
+    end
   end
 end


### PR DESCRIPTION
Gaming session overview now correctly shows upcoming games
Also now has previous tab (limited to 15 currently)